### PR TITLE
Scheduler needs to run on check instances

### DIFF
--- a/django_datawatch/tasks.py
+++ b/django_datawatch/tasks.py
@@ -31,4 +31,4 @@ class DatawatchScheduler(PeriodicTask):
 
     def run(self, *args, **kwargs):
         for check in monitor.get_all_registered_checks():
-            check.run()
+            check().run()


### PR DESCRIPTION
Received error:
TypeError: unbound method run() must be called with ActiveAdWordsCustomerPMsCheck instance as first argument (got nothing instead)