### PR TITLE
Stop executing tasks on every schedule run

### DIFF
--- a/django_datawatch/datawatch.py
+++ b/django_datawatch/datawatch.py
@@ -144,7 +144,7 @@ class Scheduler(object):
 
             # shall the check be run again?
             if not force and check.slug in last_executions:
-                if now < last_executions[check.slug] + check.run_every:
+                if now + check.run_every < last_executions[check.slug]:
                     continue
 
             # enqueue the check and save execution state


### PR DESCRIPTION
Right now, the check, if  a task should be executed is wrong, as `if now < last_execution + run_every` won't be True