### PR TITLE
Delete outdate check executions.

### DIFF
--- a/django_datawatch/management/commands/datawatch_clean_up.py
+++ b/django_datawatch/management/commands/datawatch_clean_up.py
@@ -3,7 +3,7 @@ import logging
 
 from django.core.management.base import BaseCommand
 
-from django_datawatch.models import Result
+from django_datawatch.models import Result, CheckExecution
 
 logger = logging.getLogger(__name__)
 
@@ -16,3 +16,8 @@ class Command(BaseCommand):
         check_names = list(results.distinct().values_list('slug', flat=True))
         results.delete()
         logger.info('%d results have been deleted:\n%s', len(check_names), '\n'.join(check_names))
+
+        check_executions = CheckExecution.objects.ghost_executions()
+        check_names = list(check_executions.distinct().values_list('slug', flat=True))
+        check_executions.delete()
+        logger.info('%d check executions have been deleted:\n%s', len(check_names), '\n'.join(check_names))

--- a/django_datawatch/models.py
+++ b/django_datawatch/models.py
@@ -11,6 +11,7 @@ from django_extensions.db.fields.json import JSONField
 from model_utils.choices import Choices
 from model_utils.models import TimeStampedModel
 
+from django_datawatch.querysets import CheckExecutionQuerySet
 from .datawatch import datawatch
 from .querysets import ResultQuerySet
 
@@ -84,6 +85,8 @@ class Result(TimeStampedModel):
 class CheckExecution(models.Model):
     slug = models.TextField(verbose_name=_('Check module slug'), unique=True)
     last_run = models.DateTimeField(verbose_name=_('Last run'))
+
+    objects = CheckExecutionQuerySet.as_manager()
 
     def __str__(self):
         return '%s on %s' % (self.slug, self.last_run)

--- a/django_datawatch/querysets.py
+++ b/django_datawatch/querysets.py
@@ -43,3 +43,11 @@ class ResultQuerySet(models.QuerySet):
         :return: results that do not have checks anymore (check has been deleted)
         """
         return self.exclude(slug__in=datawatch.get_all_registered_check_slugs())
+
+
+class CheckExecutionQuerySet(models.QuerySet):
+    def ghost_executions(self):
+        """
+        :return: check executions that do not have checks anymore (check has been deleted)
+        """
+        return self.exclude(slug__in=datawatch.get_all_registered_check_slugs())


### PR DESCRIPTION
Change datawatch_delete_ghost_results manage comand to datawatch_clean_up. Now it delete unused rows from two tables - Result and CheckExecutions.